### PR TITLE
Resolving API inconsistencies across different endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,9 @@ pages a requested table touches are resident. (When the container's
 `on_disk=True` serves it directly from the `.pbix`/`.xlsx` with no
 temp-file copy at all.) `PBIXRay` is a context manager; use
 `with PBIXRay(path, on_disk=True) as model:` or call `model.close()` to
-release the mapping and temp file deterministically.
+release the mapping and temp file deterministically. After `close()`,
+`get_table`/`iter_table` and any metadata not yet loaded raise
+`RuntimeError`; DataFrames already materialized remain usable.
 
 Per-table levers:
 
@@ -95,7 +97,7 @@ Source of truth: [pbixray/core.py](pbixray/core.py).
 | `get_table(name, columns=None, strings_as_categorical=False)` | `DataFrame` | Row data; `RowNumber` excluded; unknown name → empty DataFrame (no exception)             |
 | `iter_table(name, columns=None, chunk_size=None, strings_as_categorical=True)` | iterator of `DataFrame` | Chunks follow VertiPaq segment boundaries; `chunk.index` is the global row range |
 | `schema`               | `DataFrame`         | `TableName`, `ColumnName`, `PandasDataType`                                                                              |
-| `statistics`           | `DataFrame`         | `TableName`, `ColumnName`, `Cardinality`, `Dictionary`, `HashIndex`, `DataSize`                                          |
+| `statistics`           | `DataFrame`         | `TableName`, `ColumnName`, `Cardinality`, `Dictionary`, `HashIndex`, `DataSize`, `ModifiedTime`, `StructureModifiedTime` |
 | `size`                 | `int`               | Total model size in bytes                                                                                                |
 | `relationships`        | `DataFrame`         | `FromTableName`, `FromColumnName`, `ToTableName`, `ToColumnName`, `IsActive`, `Cardinality`, `CrossFilteringBehavior`, … |
 | `power_query`          | `DataFrame`         | `TableName`, `Expression` (M code, from AS metadata — import models)                                                     |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,8 @@ metadata); it has no zip envelope, so report-layer parts
 | `mashup_queries`, `data_mashup`           | Populated when the file has a `DataMashup` part | Empty / `None` |
 | `connections`                             | Populated (PBIX) / `[]` (ABF) | `[]`     |
 | `metadata`, `rls`                         | Populated   | Empty                      |
-| `aggregations`, `ols`, `perspectives`     | Populated   | **Raises `AttributeError`** (see Gotchas) |
-| `tmschema_*`                              | Populated   | Empty (except `tmschema_column_permissions`, which raises `AttributeError`) |
+| `aggregations`, `ols`, `perspectives`     | Populated   | Empty                      |
+| `tmschema_*`                              | Populated   | Empty                      |
 
 Empty here means a zero-row DataFrame, not `None` and not an exception.
 
@@ -194,12 +194,6 @@ Empty here means a zero-row DataFrame, not `None` and not an exception.
 - **Thin/live-connection reports raise on construction** — wrap
   `PBIXRay(...)` in `try/except LiveConnectionError` if the input file
   might be a live-connected report (see Exceptions).
-- **Newer roll-up endpoints raise `AttributeError` on XLSX** —
-  `aggregations`, `ols`, `perspectives`, and
-  `tmschema_column_permissions` are not implemented in the XLSX
-  metadata source, so on `.xlsx` inputs they raise instead of returning
-  an empty DataFrame. Guard with `try/except AttributeError` when the
-  input may be XLSX.
 - **`get_table` and `iter_table` default `strings_as_categorical`
   differently** — `get_table` defaults to `False` (plain object dtype),
   `iter_table` defaults to `True` (shared `pd.Categorical` across

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To inspect Power BI aggregations (the "Manage aggregations" feature) as a resolv
 aggregations = model.aggregations
 print(aggregations)
 ```
-Each row maps one aggregation-table column to a detail (base) table. `Summarization` is the human label (`GroupBy`, `Sum`, `Count`, `Min`, `Max`); `DetailColumn` is `None` for the "Count table rows" case. A PBIX model with no aggregations returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
+Each row maps one aggregation-table column to a detail (base) table. `Summarization` is the human label (`GroupBy`, `Sum`, `Count`, `Min`, `Max`); `DetailColumn` is `None` for the "Count table rows" case. A model with no aggregations returns an empty dataframe.
 ### Schema
 To get details about the data model schema and column types in a dataframe with `TableName`, `ColumnName`, and `PandasDataType` columns:
 ```python
@@ -135,14 +135,14 @@ To get object-level security restrictions as a resolved dataframe with `RoleName
 ols = model.ols
 print(ols)
 ```
-Each row is one secured object: `Scope='Column'` rows hide or expose a single column, `Scope='Table'` rows (where `ColumnName` is `None`) a whole table. `Permission` is `None` (hidden), `Read` (visible) or `Default`. Plain row-level-security rows are excluded — see `model.rls`. A PBIX model with no OLS returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
+Each row is one secured object: `Scope='Column'` rows hide or expose a single column, `Scope='Table'` rows (where `ColumnName` is `None`) a whole table. `Permission` is `None` (hidden), `Read` (visible) or `Default`. Plain row-level-security rows are excluded — see `model.rls`. A model with no OLS returns an empty dataframe.
 ### Perspectives
 To inspect perspective membership as a single consolidated dataframe with `PerspectiveName`, `ObjectType`, `TableName`, `ObjectName` and `IncludeAll` columns:
 ```python
 perspectives = model.perspectives
 print(perspectives)
 ```
-Each row is one object included in a perspective; `ObjectType` is `Table`, `Column`, `Measure` or `Hierarchy`, and `IncludeAll` is populated only for `Table` rows. This is a friendly roll-up over the raw `tmschema_perspective_*` endpoints. A PBIX model with no perspectives returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
+Each row is one object included in a perspective; `ObjectType` is `Table`, `Column`, `Measure` or `Hierarchy`, and `IncludeAll` is populated only for `Table` rows. This is a friendly roll-up over the raw `tmschema_perspective_*` endpoints. A model with no perspectives returns an empty dataframe.
 ### Get Table Contents
 To retrieve the contents of a specified table:
 ```python
@@ -179,7 +179,7 @@ whole iteration, so on dictionary-heavy models (e.g. wide free-text columns)
 pass `columns` to project only what you need. Combine with `on_disk=True` to
 also keep the decompressed model itself out of RAM.
 ### Statistics
-To get statistics about the model, including column cardinality and byte sizes of dictionary, hash index, and data components, in a dataframe with columns `TableName`, `ColumnName`, `Cardinality`, `Dictionary`, `HashIndex`, and `DataSize`:
+To get statistics about the model, including column cardinality and byte sizes of dictionary, hash index, and data components, in a dataframe with columns `TableName`, `ColumnName`, `Cardinality`, `Dictionary`, `HashIndex`, `DataSize`, `ModifiedTime`, and `StructureModifiedTime`:
 ```python
 statistics = model.statistics
 print(statistics)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To inspect Power BI aggregations (the "Manage aggregations" feature) as a resolv
 aggregations = model.aggregations
 print(aggregations)
 ```
-Each row maps one aggregation-table column to a detail (base) table. `Summarization` is the human label (`GroupBy`, `Sum`, `Count`, `Min`, `Max`); `DetailColumn` is `None` for the "Count table rows" case. A model with no aggregations returns an empty dataframe with these columns.
+Each row maps one aggregation-table column to a detail (base) table. `Summarization` is the human label (`GroupBy`, `Sum`, `Count`, `Min`, `Max`); `DetailColumn` is `None` for the "Count table rows" case. A PBIX model with no aggregations returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
 ### Schema
 To get details about the data model schema and column types in a dataframe with `TableName`, `ColumnName`, and `PandasDataType` columns:
 ```python
@@ -135,14 +135,14 @@ To get object-level security restrictions as a resolved dataframe with `RoleName
 ols = model.ols
 print(ols)
 ```
-Each row is one secured object: `Scope='Column'` rows hide or expose a single column, `Scope='Table'` rows (where `ColumnName` is `None`) a whole table. `Permission` is `None` (hidden), `Read` (visible) or `Default`. Plain row-level-security rows are excluded — see `model.rls`. A model with no OLS returns an empty dataframe with these columns.
+Each row is one secured object: `Scope='Column'` rows hide or expose a single column, `Scope='Table'` rows (where `ColumnName` is `None`) a whole table. `Permission` is `None` (hidden), `Read` (visible) or `Default`. Plain row-level-security rows are excluded — see `model.rls`. A PBIX model with no OLS returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
 ### Perspectives
 To inspect perspective membership as a single consolidated dataframe with `PerspectiveName`, `ObjectType`, `TableName`, `ObjectName` and `IncludeAll` columns:
 ```python
 perspectives = model.perspectives
 print(perspectives)
 ```
-Each row is one object included in a perspective; `ObjectType` is `Table`, `Column`, `Measure` or `Hierarchy`, and `IncludeAll` is populated only for `Table` rows. This is a friendly roll-up over the raw `tmschema_perspective_*` endpoints. A model with no perspectives returns an empty dataframe with these columns.
+Each row is one object included in a perspective; `ObjectType` is `Table`, `Column`, `Measure` or `Hierarchy`, and `IncludeAll` is populated only for `Table` rows. This is a friendly roll-up over the raw `tmschema_perspective_*` endpoints. A PBIX model with no perspectives returns an empty dataframe with these columns; on XLSX (no equivalent feature) the dataframe is empty and column-less.
 ### Get Table Contents
 To retrieve the contents of a specified table:
 ```python

--- a/pbixray/core.py
+++ b/pbixray/core.py
@@ -139,8 +139,10 @@ class PBIXRay:
         Columns: ``AggregationTable, AggregationColumn, Summarization,
         DetailTable, DetailColumn``. One row per aggregation-table column mapped
         to its detail (base) table; ``DetailColumn`` is ``None`` for the
-        "Count table rows" case. Empty (with those columns) when the model has
-        no aggregations. Friendly layer over ``tmschema_alternate_of``.
+        "Count table rows" case. A PBIX model with no aggregations returns an
+        empty DataFrame with those columns; on XLSX (no equivalent feature)
+        the DataFrame is empty and column-less, like the other PBIX-only
+        endpoints. Friendly layer over ``tmschema_alternate_of``.
         """
         return self._metadata.source.aggregations_df
 
@@ -223,7 +225,9 @@ class PBIXRay:
         ``Scope='Table'`` rows (``ColumnName`` is ``None``) hide/expose a whole
         table. ``Permission`` is ``None`` (hidden), ``Read`` (visible) or
         ``Default``. Plain row-level-security rows are excluded (see ``rls``).
-        Empty (with those columns) when the model has no OLS. Friendly layer over
+        A PBIX model with no OLS returns an empty DataFrame with those columns;
+        on XLSX (no equivalent feature) the DataFrame is empty and column-less,
+        like the other PBIX-only endpoints. Friendly layer over
         ``tmschema_column_permissions`` and the table permissions.
         """
         return self._metadata.source.ols_df
@@ -235,9 +239,11 @@ class PBIXRay:
         Columns: ``PerspectiveName, ObjectType, TableName, ObjectName,
         IncludeAll``. One row per object included in a perspective, with
         ``ObjectType`` one of ``Table, Column, Measure, Hierarchy``;
-        ``IncludeAll`` is populated only for ``Table`` rows. Empty (with those
-        columns) when the model has no perspectives. Friendly roll-up over the
-        raw ``tmschema_perspective_*`` rowsets.
+        ``IncludeAll`` is populated only for ``Table`` rows. A PBIX model with
+        no perspectives returns an empty DataFrame with those columns; on XLSX
+        (no equivalent feature) the DataFrame is empty and column-less, like
+        the other PBIX-only endpoints. Friendly roll-up over the raw
+        ``tmschema_perspective_*`` rowsets.
         """
         return self._metadata.source.perspectives_view_df
 

--- a/pbixray/core.py
+++ b/pbixray/core.py
@@ -28,9 +28,16 @@ class PBIXRay:
         self._connections = loader.connections
         self._data_mashup_bytes = loader.data_mashup_bytes
         self._data_mashup = None  # parsed lazily on first access
+        self._closed = False
 
         self._metadata = Metadata(self._data_model)
         self._vertipaq_decoder = VertiPaqDecoder(self._metadata.source, self._data_model)
+
+    def _ensure_open(self):
+        if self._closed:
+            raise RuntimeError(
+                "This PBIXRay model is closed; create a new PBIXRay to keep reading."
+            )
 
     def get_table(self, table_name, columns=None, strings_as_categorical=False):
         """Generates a DataFrame representation of the specified table.
@@ -45,6 +52,7 @@ class PBIXRay:
                 instead of once per row. Default ``False`` keeps the original
                 object-dtype output.
         """
+        self._ensure_open()
         return self._vertipaq_decoder.get_table(
             table_name, columns=columns, strings_as_categorical=strings_as_categorical
         )
@@ -77,6 +85,7 @@ class PBIXRay:
         Yields:
             ``pd.DataFrame`` chunks whose index is the global row range.
         """
+        self._ensure_open()
         return self._vertipaq_decoder.iter_table(
             table_name,
             columns=columns,
@@ -87,13 +96,15 @@ class PBIXRay:
     def close(self):
         """Release OS resources (memory-map / temp file, metadata connection).
 
-        Safe to call multiple times. Only has an effect for ``on_disk=True``
-        models and the metadata SQLite connection.
+        Safe to call multiple times. After closing, ``get_table``/``iter_table``
+        and any metadata not yet loaded raise a ``RuntimeError``; DataFrames
+        already materialized remain usable.
         """
         source = getattr(self._metadata, 'source', None)
         if source is not None and hasattr(source, 'close'):
             source.close()
         self._data_model.close()
+        self._closed = True
 
     def __enter__(self):
         return self
@@ -139,10 +150,8 @@ class PBIXRay:
         Columns: ``AggregationTable, AggregationColumn, Summarization,
         DetailTable, DetailColumn``. One row per aggregation-table column mapped
         to its detail (base) table; ``DetailColumn`` is ``None`` for the
-        "Count table rows" case. A PBIX model with no aggregations returns an
-        empty DataFrame with those columns; on XLSX (no equivalent feature)
-        the DataFrame is empty and column-less, like the other PBIX-only
-        endpoints. Friendly layer over ``tmschema_alternate_of``.
+        "Count table rows" case. Empty (column-less) when the model has no
+        aggregations. Friendly layer over ``tmschema_alternate_of``.
         """
         return self._metadata.source.aggregations_df
 
@@ -191,13 +200,11 @@ class PBIXRay:
         """Power Query queries/parameters from the ``DataMashup`` as a DataFrame.
 
         Columns: ``Name, Kind, IsParameter, Expression, Type, DefaultValue,
-        AllowedValues``. Empty (with those columns) when the file has no mashup.
+        AllowedValues``. Empty (column-less) when the file has no mashup.
         """
-        columns = ['Name', 'Kind', 'IsParameter', 'Expression',
-                   'Type', 'DefaultValue', 'AllowedValues']
         mashup = self.data_mashup
         if mashup is None:
-            return pd.DataFrame(columns=columns)
+            return pd.DataFrame()
         rows = [
             {
                 'Name': q.name,
@@ -210,7 +217,12 @@ class PBIXRay:
             }
             for q in mashup.queries
         ]
-        return pd.DataFrame(rows, columns=columns)
+        if not rows:
+            return pd.DataFrame()
+        return pd.DataFrame(rows, columns=[
+            'Name', 'Kind', 'IsParameter', 'Expression',
+            'Type', 'DefaultValue', 'AllowedValues',
+        ])
 
     @property
     def rls(self):
@@ -225,9 +237,7 @@ class PBIXRay:
         ``Scope='Table'`` rows (``ColumnName`` is ``None``) hide/expose a whole
         table. ``Permission`` is ``None`` (hidden), ``Read`` (visible) or
         ``Default``. Plain row-level-security rows are excluded (see ``rls``).
-        A PBIX model with no OLS returns an empty DataFrame with those columns;
-        on XLSX (no equivalent feature) the DataFrame is empty and column-less,
-        like the other PBIX-only endpoints. Friendly layer over
+        Empty (column-less) when the model has no OLS. Friendly layer over
         ``tmschema_column_permissions`` and the table permissions.
         """
         return self._metadata.source.ols_df
@@ -239,11 +249,9 @@ class PBIXRay:
         Columns: ``PerspectiveName, ObjectType, TableName, ObjectName,
         IncludeAll``. One row per object included in a perspective, with
         ``ObjectType`` one of ``Table, Column, Measure, Hierarchy``;
-        ``IncludeAll`` is populated only for ``Table`` rows. A PBIX model with
-        no perspectives returns an empty DataFrame with those columns; on XLSX
-        (no equivalent feature) the DataFrame is empty and column-less, like
-        the other PBIX-only endpoints. Friendly roll-up over the raw
-        ``tmschema_perspective_*`` rowsets.
+        ``IncludeAll`` is populated only for ``Table`` rows. Empty
+        (column-less) when the model has no perspectives. Friendly roll-up
+        over the raw ``tmschema_perspective_*`` rowsets.
         """
         return self._metadata.source.perspectives_view_df
 

--- a/pbixray/meta/sqlite_source.py
+++ b/pbixray/meta/sqlite_source.py
@@ -49,12 +49,6 @@ class SqliteMetadataSource:
         'ModifiedTime', 'StructureModifiedTime',
     ]
 
-    # Friendly, resolved aggregations view (see ``__populate_aggregations``).
-    _AGGREGATIONS_COLUMNS = [
-        'AggregationTable', 'AggregationColumn', 'Summarization',
-        'DetailTable', 'DetailColumn',
-    ]
-
     # ``AlternateOf.Summarization`` enum -> human label.
     _SUMMARIZATION_LABELS = {
         0: 'GroupBy', 1: 'Sum', 2: 'Count', 3: 'Min', 4: 'Max',
@@ -71,12 +65,6 @@ class SqliteMetadataSource:
     _METADATA_PERMISSION_LABELS = {
         0: 'Default', 1: 'None', 2: 'Read',
     }
-
-    # Friendly, consolidated perspective-membership view (see
-    # ``__populate_perspectives_view``).
-    _PERSPECTIVES_COLUMNS = [
-        'PerspectiveName', 'ObjectType', 'TableName', 'ObjectName', 'IncludeAll',
-    ]
 
     def __init__(self, data_model: DataModel):
         self._data_model = data_model
@@ -158,6 +146,11 @@ class SqliteMetadataSource:
         """
         populators = self.__dict__.get('_lazy_populators')
         if populators and name in populators:
+            if self.__dict__.get('_db') is None:
+                raise RuntimeError(
+                    "This PBIXRay model is closed; metadata not loaded before "
+                    "close() is no longer available."
+                )
             df = convert_time_columns(populators[name]())
             setattr(self, name, df)  # cache for subsequent access
             return df
@@ -1137,9 +1130,9 @@ class SqliteMetadataSource:
         """
         df = self._db.query(sql)
         if df.empty:
-            # Missing ``AlternateOf`` (legacy schema) or no aggregations: give a
-            # stable shape so callers can always select the canonical columns.
-            return df.reindex(columns=self._AGGREGATIONS_COLUMNS)
+            # Missing ``AlternateOf`` (legacy schema) or no aggregations:
+            # column-less empty frame, like every other endpoint.
+            return df
         df['Summarization'] = df['Summarization'].map(self._SUMMARIZATION_LABELS)
         return df
 
@@ -1286,8 +1279,8 @@ class SqliteMetadataSource:
           surfaced by ``rls`` instead.
 
         ``Permission`` is the human label (``None`` hides the object, ``Read``
-        makes it visible). Empty (with the canonical columns) when the model has
-        no OLS or predates the permission tables.
+        makes it visible). Empty (column-less) when the model has no OLS or
+        predates the permission tables.
         """
         sql = """
         SELECT
@@ -1318,9 +1311,9 @@ class SqliteMetadataSource:
         df = self._db.query(sql)
         if df.empty:
             # No OLS, or a legacy schema lacking the permission tables / the
-            # ``MetadataPermission`` column: give a stable shape so callers can
-            # always select the canonical columns.
-            return df.reindex(columns=self._OLS_COLUMNS)
+            # ``MetadataPermission`` column: column-less empty frame, like
+            # every other endpoint.
+            return df
         df['Permission'] = df.pop('_Perm').map(self._METADATA_PERMISSION_LABELS)
         return df.reindex(columns=self._OLS_COLUMNS)
 
@@ -1336,8 +1329,8 @@ class SqliteMetadataSource:
         single frame keyed by ``ObjectType``. ``TableName`` is the owning table
         for every row; ``ObjectName`` is the object's own name (equal to
         ``TableName`` for ``Table`` rows). ``IncludeAll`` is populated only for
-        ``Table`` rows (whether the whole table is included). Empty (with the
-        canonical columns) when the model has no perspectives.
+        ``Table`` rows (whether the whole table is included). Empty
+        (column-less) when the model has no perspectives.
         """
         sql = """
         SELECT
@@ -1376,6 +1369,6 @@ class SqliteMetadataSource:
         JOIN [Table]              t  ON h.TableID             = t.ID
         ORDER BY PerspectiveName, ObjectType, TableName, ObjectName;
         """
-        # ``reindex`` gives a stable shape whether or not the model has
-        # perspectives (an all-empty union comes back column-less from APSW).
-        return self._db.query(sql).reindex(columns=self._PERSPECTIVES_COLUMNS)
+        # An all-empty union comes back column-less from APSW — left as-is,
+        # like every other endpoint's empty case.
+        return self._db.query(sql)

--- a/pbixray/meta/xml_source.py
+++ b/pbixray/meta/xml_source.py
@@ -32,7 +32,8 @@ _EMPTY_DF_STUBS = (
     'calendar_column_groups_df', 'calendar_column_refs_df', 'alternate_of_df',
     'related_column_details_df', 'group_by_columns_df', 'binding_info_df',
     'analytics_ai_metadata_df', 'data_coverage_definitions_df',
-    'role_memberships_df',
+    'role_memberships_df', 'column_permissions_df',
+    'aggregations_df', 'ols_df', 'perspectives_view_df',
 )
 
 

--- a/pbixray/vertipaq_decoder.py
+++ b/pbixray/vertipaq_decoder.py
@@ -398,11 +398,12 @@ class VertiPaqDecoder:
     def _select_table_metadata(self, table_name, columns):
         """Filters schema_df to the requested table and (optionally) columns.
 
-        Unknown column names raise a ``ValueError``; an unknown table simply
-        yields an empty selection.
+        An unknown table yields an empty selection — with or without
+        ``columns`` — so the caller's empty-result contract holds. Unknown
+        column names on a *known* table raise a ``ValueError``.
         """
         table_metadata_df = self._meta.schema_df[self._meta.schema_df['TableName'] == table_name]
-        if columns is not None:
+        if columns is not None and not table_metadata_df.empty:
             available = set(table_metadata_df['ColumnName'])
             missing = [c for c in columns if c not in available]
             if missing:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pbixray',
-    version='0.15.0',
+    version='0.15.1',
     packages=find_packages(),
     install_requires=[
         'xpress8',

--- a/test/test_aggregations.py
+++ b/test/test_aggregations.py
@@ -66,7 +66,7 @@ def test_aggregations_groupby_resolves_own_detail_table(aggregations_model):
 
 
 def test_aggregations_empty_model(rls_model):
+    # Column-less when empty, like every other endpoint's empty case.
     df = rls_model.aggregations
     assert isinstance(df, pd.DataFrame)
     assert df.empty
-    assert list(df.columns) == _AGG_COLUMNS

--- a/test/test_mashup.py
+++ b/test/test_mashup.py
@@ -48,13 +48,11 @@ def test_power_query_and_m_parameters_unchanged(directquery_model):
 
 
 def test_model_without_mashup(sales_returns_model):
+    # Column-less empty frame, like every other endpoint's empty case.
     assert sales_returns_model.data_mashup is None
     df = sales_returns_model.mashup_queries
-    assert list(df.columns) == [
-        "Name", "Kind", "IsParameter", "Expression",
-        "Type", "DefaultValue", "AllowedValues",
-    ]
-    assert len(df) == 0
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_ols_perspectives.py
+++ b/test/test_ols_perspectives.py
@@ -52,11 +52,10 @@ def test_ols_excludes_plain_rls(ols_model):
 
 def test_ols_empty_shape(rls_model):
     # A model with row-level security but no object-level security returns an
-    # empty frame with the canonical columns (not a column-less frame).
+    # empty frame — column-less, like every other endpoint's empty case.
     df = rls_model.ols
     assert isinstance(df, pd.DataFrame)
     assert df.empty
-    assert list(df.columns) == _OLS_COLUMNS
 
 
 def test_tmschema_column_permissions(ols_model):
@@ -97,8 +96,8 @@ def test_perspectives_membership(internet_sales_abf_model):
 
 
 def test_perspectives_empty_shape(abc_model):
-    # A model with no perspectives returns an empty frame with canonical columns.
+    # A model with no perspectives returns an empty frame — column-less, like
+    # every other endpoint's empty case.
     df = abc_model.perspectives
     assert isinstance(df, pd.DataFrame)
     assert df.empty
-    assert list(df.columns) == _PERSPECTIVES_COLUMNS

--- a/test/test_on_disk.py
+++ b/test/test_on_disk.py
@@ -82,6 +82,30 @@ def test_close_is_idempotent(tmp_path):
     model.close()  # must not raise
 
 
+@pytest.mark.parametrize("on_disk", [False, True])
+def test_use_after_close_raises_clearly(on_disk, tmp_path):
+    """After close(), data and unloaded-metadata access raise a RuntimeError
+    that says the model is closed — same behavior in both loading modes."""
+    model = PBIXRay(os.path.join(DATA_DIR, "work.pbix"), on_disk=on_disk,
+                    temp_dir=str(tmp_path) if on_disk else None)
+    table = model.tables[0]
+    model.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        model.get_table(table)
+    with pytest.raises(RuntimeError, match="closed"):
+        next(model.iter_table(table))
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = model.dax_measures  # lazy metadata, not loaded before close
+
+
+def test_metadata_loaded_before_close_stays_readable():
+    """close() releases resources; already-materialized DataFrames survive."""
+    model = PBIXRay(os.path.join(DATA_DIR, "work.pbix"))
+    measures = model.dax_measures
+    model.close()
+    assert model.dax_measures is measures
+
+
 def test_column_selection():
     """get_table(columns=[...]) returns only the requested columns, matching the full decode."""
     model = PBIXRay(os.path.join(DATA_DIR, "work.pbix"))
@@ -99,6 +123,15 @@ def test_column_selection_unknown_raises():
     table = model.tables[0]
     with pytest.raises(ValueError):
         model.get_table(table, columns=["__definitely_not_a_column__"])
+
+
+def test_unknown_table_is_forgiving_with_or_without_columns():
+    """Unknown table name -> empty DataFrame, even when columns are requested;
+    iter_table yields nothing. Column validation only applies to known tables."""
+    model = PBIXRay(os.path.join(DATA_DIR, "work.pbix"))
+    assert model.get_table("__no_such_table__").empty
+    assert model.get_table("__no_such_table__", columns=["anything"]).empty
+    assert list(model.iter_table("__no_such_table__")) == []
 
 
 def test_metadata_loaded_lazily():

--- a/test/test_xlsx.py
+++ b/test/test_xlsx.py
@@ -74,6 +74,20 @@ def test_xlsx_relationships(xlsx_model):
 
 
 # -------------------------------------------------------------------------
+# Endpoints with no XLSX equivalent must still return an empty DataFrame
+# (uniform surface with PBIX), never raise.
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["aggregations", "ols", "perspectives", "tmschema_column_permissions"],
+)
+def test_xlsx_pbix_only_endpoints_empty(xlsx_model, endpoint):
+    df = getattr(xlsx_model, endpoint)
+    assert _is_df(df) and df.empty
+
+
+# -------------------------------------------------------------------------
 # get_table data fidelity — verified against CSV fixtures captured from
 # Excel's Power Pivot view. Compared as row-tuple multisets because
 # VertiPaq stores rows in RLE-friendly order, not insertion order.


### PR DESCRIPTION
* Default to column-less empty dataframe 
* model close behaviour
* docs update