### PR TITLE
fix dictionary misalignment caused by overly optimistic regex (#56)

### DIFF
--- a/pbixray/meta/xml_source.py
+++ b/pbixray/meta/xml_source.py
@@ -416,11 +416,33 @@ class XmlMetadataSource:
         }
         return type_map.get(ssas_type, 'object')
     
+    @staticmethod
+    def _dimension_file_pattern(dimension_id):
+        """Matches the dimension token of a data file name.
+
+        Data files are named ``<n>.<dimension_id>.<column>.<ext>`` or
+        ``<n>.H$<dimension_id>$<column>.<ext>``, so the dimension id is a
+        delimited token, not just a substring. Testing it as a substring
+        misattributes files across tables whenever one dimension's id also
+        appears inside another table's *column* name: in Customer
+        Profitability, dimension ``Product`` matched
+        ``17.Fact_<guid>.Product Key.dictionary`` and adopted the fact
+        table's hash dictionary for its own value-encoded Product Key.
+
+        The leading ``<n>.`` is optional so a writer that omits it still
+        resolves; what matters is that the id is bounded by ``.`` or ``$``
+        on both sides.
+        """
+        return re.compile(
+            r'(?:^|\.)(?:H\$)?' + re.escape(dimension_id) + r'[.$]'
+        )
+
     def _find_column_files(self, dimension_id, column_name):
         files = {'dictionary': '', 'hidx': '', 'idf': ''}
+        dimension_pattern = self._dimension_file_pattern(dimension_id)
         for file_entry in self.data_model.file_log:
             file_name = file_entry['FileName']
-            if (dimension_id in file_name or f"H${dimension_id}" in file_name) and column_name in file_name:
+            if column_name in file_name and dimension_pattern.search(file_name):
                 if '.dictionary' in file_name and not '.ID_TO_POS.' in file_name and not '.POS_TO_ID.' in file_name:
                     if f".{column_name}.0.idf.dictionary" in file_name or f".{column_name}.dictionary" in file_name:
                         files['dictionary'] = file_name

--- a/test/test_xlsx.py
+++ b/test/test_xlsx.py
@@ -108,6 +108,40 @@ def test_xlsx_get_table_matches_fixture(xlsx_model, table):
     )
 
 
+# -------------------------------------------------------------------------
+# Data files are named <n>.<dimension_id>.<column>.<ext> (hierarchy files use
+# <n>.H$<dimension_id>$<column>.<ext>), so the dimension id is a delimited
+# token. Matching it as a bare substring handed one table's files to another
+# whenever a dimension id also appeared inside some other table's column name.
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "dimension_id, file_name, owned",
+    [
+        # Files the dimension really owns.
+        ("Product", "0.Product.Product Key.0.idf", True),
+        ("Product", "0.Product.Product.dictionary", True),
+        ("Product", "3.H$Product$Product Key.hidx", True),
+        ("Fact_fb28d60b", "17.Fact_fb28d60b.Product Key.dictionary", True),
+        ("Fact_fb28d60b", "6.H$Fact_fb28d60b$Product Key.POS_TO_ID.0.idf", True),
+        # The Customer Profitability collision: "Product"/"Scenario" occur
+        # inside the fact table's column names, never as its dimension token.
+        ("Product", "17.Fact_fb28d60b.Product Key.dictionary", False),
+        ("Scenario", "17.Fact_fb28d60b.Scenario Key.dictionary", False),
+        # An id that is only a prefix or a suffix of the real one.
+        ("Fact", "17.Fact_fb28d60b.Product Key.dictionary", False),
+        ("fb28d60b", "17.Fact_fb28d60b.Product Key.dictionary", False),
+    ],
+)
+def test_dimension_file_pattern_matches_only_its_own_token(
+    dimension_id, file_name, owned
+):
+    from pbixray.meta.xml_source import XmlMetadataSource
+
+    pattern = XmlMetadataSource._dimension_file_pattern(dimension_id)
+    assert bool(pattern.search(file_name)) is owned
+
+
 def test_xlsx_get_table_no_rownumber_column(xlsx_model):
     # RowNumber is VertiPaq's internal storage position; we hide it the
     # same way PBIX does, so get_table only exposes user-facing columns.

--- a/test/test_xlsx.py
+++ b/test/test_xlsx.py
@@ -4,9 +4,14 @@ Tests for xlsx parsing support.
 PBIXRay accepts Excel workbooks (.xlsx) in addition to .pbix files — the same
 API surface applies. The fixture is provided by conftest.py (xlsx_model).
 """
+import glob
 import os
+import re
+
 import pandas as pd
 import pytest
+
+from pbixray import PBIXRay
 
 CSV_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "xlsx")
 
@@ -140,6 +145,127 @@ def test_dimension_file_pattern_matches_only_its_own_token(
 
     pattern = XmlMetadataSource._dimension_file_pattern(dimension_id)
     assert bool(pattern.search(file_name)) is owned
+
+
+# -------------------------------------------------------------------------
+# Column file attribution.
+#
+# Files are named <n>.<dimension_id>.<column>.<ext>, or
+# <n>.H$<dimension_id>$<column>.<ext> for hierarchy files. The dimension id is
+# the *storage* id, which keeps the table's original name after a rename
+# (Supplier Quality shows 'Category' stored as 'Sub Category_<guid>'), so file
+# lookup has to key on it rather than on the display name. Storage ids carry a
+# guid suffix, which is what makes them collide when tested as bare substrings:
+# dimension 'Product' matched '17.Fact_<guid>.Product Key.dictionary' and took
+# the fact table's dictionary for its own value-encoded column.
+#
+# The sweeps below run over every workbook available, including the two that
+# have no PBIX counterpart to cross-validate against.
+# -------------------------------------------------------------------------
+
+SAMPLES_DIR = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "samples",
+    "powerbi-desktop-samples", "powerbi-service-samples"))
+
+_DATA_WORKBOOKS = ["Supplier Quality Analysis Sample-no-PV.xlsx", "null_data_id.xlsx"]
+
+
+def _workbook_paths():
+    paths = [os.path.join(os.path.dirname(__file__), "..", "data", n)
+             for n in _DATA_WORKBOOKS]
+    if os.path.isdir(SAMPLES_DIR):
+        paths += sorted(glob.glob(os.path.join(SAMPLES_DIR, "*.xlsx")))
+    return paths
+
+
+@pytest.fixture(scope="module")
+def workbook_source(request):
+    return PBIXRay(request.param)._vertipaq_decoder._meta
+
+
+_WORKBOOKS = pytest.mark.parametrize(
+    "workbook_source", _workbook_paths(), ids=os.path.basename, indirect=True)
+
+
+@pytest.mark.parametrize(
+    "dimension_id, file_name, owned",
+    [
+        # Files the dimension really owns.
+        ("Product", "0.Product.Product Key.0.idf", True),
+        ("Product", "0.Product.Product.dictionary", True),
+        ("Product", "3.H$Product$Product Key.hidx", True),
+        ("Fact_fb28d60b", "17.Fact_fb28d60b.Product Key.dictionary", True),
+        ("Fact_fb28d60b", "6.H$Fact_fb28d60b$Product Key.POS_TO_ID.0.idf", True),
+        # The Customer Profitability collision: "Product"/"Scenario" occur
+        # inside the fact table's column names, never as its dimension token.
+        ("Product", "17.Fact_fb28d60b.Product Key.dictionary", False),
+        ("Scenario", "17.Fact_fb28d60b.Scenario Key.dictionary", False),
+        # A storage id truncated to the part before the guid, or to the guid.
+        ("Fact", "17.Fact_fb28d60b.Product Key.dictionary", False),
+        ("fb28d60b", "17.Fact_fb28d60b.Product Key.dictionary", False),
+    ],
+)
+def test_dimension_file_pattern_matches_only_its_own_token(
+    dimension_id, file_name, owned
+):
+    from pbixray.meta.xml_source import XmlMetadataSource
+
+    pattern = XmlMetadataSource._dimension_file_pattern(dimension_id)
+    assert bool(pattern.search(file_name)) is owned
+
+
+@_WORKBOOKS
+def test_column_files_belong_to_their_own_dimension(workbook_source):
+    """No column may be handed a file owned by another dimension.
+
+    Borrowing another table's dictionary is silent whenever the two id spaces
+    happen to agree -- Scenario[Scenario Key] decoded correctly for exactly
+    that reason -- so attribution is checked directly rather than by waiting
+    for decoded values to disagree.
+    """
+    for _, column in workbook_source.schema_df.iterrows():
+        pattern = workbook_source._dimension_file_pattern(column["DimensionID"])
+        for key in ("Dictionary", "HIDX", "IDF"):
+            file_name = column[key]
+            if not (pd.notnull(file_name) and file_name):
+                continue
+            assert pattern.search(file_name), (
+                f"{column['TableName']}[{column['ColumnName']}] {key} -> "
+                f"{file_name} does not belong to dimension "
+                f"{column['DimensionID']!r}"
+            )
+
+
+@_WORKBOOKS
+def test_dimension_id_is_an_exact_storage_token(workbook_source):
+    """Every dimension id must appear verbatim as a file-name token.
+
+    Matching the id as a delimited token only resolves files while the id
+    equals the token exactly. If a writer ever emits a truncated or otherwise
+    divergent id, the lookup would return nothing and columns would decode as
+    empty -- so pin the assumption here, where it fails loudly.
+    """
+    tokens = set()
+    for file_entry in workbook_source.data_model.file_log:
+        match = re.match(r'^\d+\.(?:H\$)?([^.$]+)[.$]', file_entry['FileName'])
+        if match and file_entry['FileName'].endswith(('.dictionary', '.idf', '.hidx')):
+            tokens.add(match.group(1))
+    for dimension_id in workbook_source.schema_df['DimensionID'].unique():
+        assert dimension_id in tokens, (
+            f"dimension {dimension_id!r} has no exactly-matching file token; "
+            f"closest: {[t for t in tokens if dimension_id in t or t in dimension_id]}"
+        )
+
+
+@_WORKBOOKS
+def test_every_column_resolves_its_idf(workbook_source):
+    """Anchoring the dimension match must not drop a file it used to find."""
+    missing = [
+        f"{c['TableName']}[{c['ColumnName']}]"
+        for _, c in workbook_source.schema_df.iterrows()
+        if not (pd.notnull(c["IDF"]) and c["IDF"])
+    ]
+    assert not missing, f"columns with no IDF: {missing}"
 
 
 def test_xlsx_get_table_no_rownumber_column(xlsx_model):

--- a/test/test_xlsx_pbix_crossvalidation.py
+++ b/test/test_xlsx_pbix_crossvalidation.py
@@ -158,32 +158,6 @@ def test_shifted_base_columns_match_pbix(models):
 
 
 @pytest.mark.parametrize("models", PAIRS, ids=_pair_id, indirect=True)
-def test_column_files_belong_to_their_own_dimension(models):
-    """Every resolved data file must be owned by the column's own dimension.
-
-    The general invariant behind CROSS_DIMENSION_COLLISION_COLUMNS: file names
-    are ``<n>.<dimension_id>.<column>.<ext>`` (or ``<n>.H$<dimension_id>$...``),
-    so a column may only be handed files whose dimension token is its own.
-    Borrowing another table's dictionary is silent whenever the two id spaces
-    happen to agree, so this checks attribution directly rather than waiting
-    for the decoded values to disagree.
-    """
-    _, xlsx_model, _ = models
-    source = xlsx_model._vertipaq_decoder._meta
-    for _, column in source.schema_df.iterrows():
-        pattern = source._dimension_file_pattern(column["DimensionID"])
-        for key in ("Dictionary", "HIDX", "IDF"):
-            file_name = column[key]
-            if not (pd.notnull(file_name) and file_name):
-                continue
-            assert pattern.search(file_name), (
-                f"{column['TableName']}[{column['ColumnName']}] {key} -> "
-                f"{file_name} does not belong to dimension "
-                f"{column['DimensionID']!r}"
-            )
-
-
-@pytest.mark.parametrize("models", PAIRS, ids=_pair_id, indirect=True)
 def test_collision_columns_match_pbix_by_value(models):
     """The collision columns must decode to the PBIX values, not just its shape."""
     xlsx_name, xlsx_model, pbix_model = models

--- a/test/test_xlsx_pbix_crossvalidation.py
+++ b/test/test_xlsx_pbix_crossvalidation.py
@@ -62,15 +62,26 @@ SHIFTED_BASE_COLUMNS = {
 }
 
 # Columns that differ for a reason unrelated to the dictionary base, tracked so
-# they surface when fixed rather than being silently tolerated.
+# they surface when fixed rather than being silently tolerated. Empty today;
+# kept as the mechanism for recording the next one.
+KNOWN_DIFFERENCES = set()
+
+# Columns whose dimension id also occurs inside another table's *column* name,
+# so a substring test on the id attributed that table's files to them. Both live
+# in Customer Profitability, where dimension ``Product`` matched
+# ``17.Fact_<guid>.Product Key.dictionary`` and dimension ``Scenario`` matched
+# the fact table's ``Scenario Key`` dictionary. Both columns are value-encoded
+# and own no dictionary at all.
 #
-# Product[Product Key] is value-encoded -- its ids are 3/13/23/33/73/75 and
-# id + BaseId(7) gives 10/20/30/40/80/82, exactly the PBIX values -- but the
-# XLSX schema also names a Dictionary file for it, so _ColumnDecoder takes the
-# dictionary branch, builds a six-entry lookup keyed 3..8, and every id except
-# the first misses it and becomes NaN. Separate bug, separate fix.
-KNOWN_DIFFERENCES = {
-    ("Customer Profitability Sample-no-PV.xlsx", "Product", "Product Key"),
+# Only Product[Product Key] decoded visibly wrong (ids 3/13/23/33/73/75 against
+# a borrowed lookup keyed 3..9: one hit, five NaN). Scenario[Scenario Key] came
+# out right by coincidence -- its ids 3/4 map to 1/2 in the fact dictionary,
+# which is also what id + BaseId(-2) gives -- so it is pinned by value here;
+# a row/null/distinct profile never distinguished it.
+CROSS_DIMENSION_COLLISION_COLUMNS = {
+    "Customer Profitability Sample-no-PV.xlsx": [
+        ("Product", "Product Key"), ("Scenario", "Scenario Key"),
+    ],
 }
 
 pytestmark = pytest.mark.skipif(
@@ -144,6 +155,45 @@ def test_shifted_base_columns_match_pbix(models):
         values = _string_values(from_pbix)
         if values is not None:
             assert _string_values(from_xlsx) == values, f"{table}[{column}]"
+
+
+@pytest.mark.parametrize("models", PAIRS, ids=_pair_id, indirect=True)
+def test_column_files_belong_to_their_own_dimension(models):
+    """Every resolved data file must be owned by the column's own dimension.
+
+    The general invariant behind CROSS_DIMENSION_COLLISION_COLUMNS: file names
+    are ``<n>.<dimension_id>.<column>.<ext>`` (or ``<n>.H$<dimension_id>$...``),
+    so a column may only be handed files whose dimension token is its own.
+    Borrowing another table's dictionary is silent whenever the two id spaces
+    happen to agree, so this checks attribution directly rather than waiting
+    for the decoded values to disagree.
+    """
+    _, xlsx_model, _ = models
+    source = xlsx_model._vertipaq_decoder._meta
+    for _, column in source.schema_df.iterrows():
+        pattern = source._dimension_file_pattern(column["DimensionID"])
+        for key in ("Dictionary", "HIDX", "IDF"):
+            file_name = column[key]
+            if not (pd.notnull(file_name) and file_name):
+                continue
+            assert pattern.search(file_name), (
+                f"{column['TableName']}[{column['ColumnName']}] {key} -> "
+                f"{file_name} does not belong to dimension "
+                f"{column['DimensionID']!r}"
+            )
+
+
+@pytest.mark.parametrize("models", PAIRS, ids=_pair_id, indirect=True)
+def test_collision_columns_match_pbix_by_value(models):
+    """The collision columns must decode to the PBIX values, not just its shape."""
+    xlsx_name, xlsx_model, pbix_model = models
+    for table, column in CROSS_DIMENSION_COLLISION_COLUMNS.get(xlsx_name, []):
+        from_xlsx = xlsx_model.get_table(table, columns=[column])[column]
+        from_pbix = pbix_model.get_table(table, columns=[column])[column]
+        assert sorted(from_xlsx.dropna()) == sorted(from_pbix.dropna()), (
+            f"{table}[{column}]"
+        )
+        assert _profile(from_xlsx) == _profile(from_pbix), f"{table}[{column}]"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Problem

`Product[Product Key]` in `Customer Profitability Sample-no-PV.xlsx` decoded as `[82, NaN, NaN, NaN, NaN, NaN]`; the equivalent PBIX gives `[10, 20, 30, 40, 80, 82]`.

The column is value-encoded and owns no dictionary — just an IDF and a HIDX, with `BaseId=7`. But the schema named a dictionary for it anyway, and that dictionary belongs to the **Fact** table:

    Dictionary -> 17.Fact_<guid>.Product Key.dictionary
    HIDX       -> 3.H$Product$Product Key.hidx
    IDF        -> 0.Product.Product Key.0.idf

`_find_column_files` matched the dimension id as a bare substring. The dimension id here is literally `Product`, which occurs inside the fact table's *column* name `Product Key`, so the Product dimension adopted the fact table's hash
dictionary. `_ColumnDecoder` then took the dictionary branch and looked the column's ids `[3, 13, 23, 33, 73, 75]` up in a table keyed 3..9 from an unrelated id space: id 3 hit (`'82'`, the one value that appeared), the rest missed and became NaN.

`Scenario[Scenario Key]` had the same misattribution but decoded correctly by coincidence — its ids 3/4 map to 1/2 in the borrowed dictionary, which is also what `id + BaseId(-2)` gives — which is why the cross-validation sweep only ever flagged one of the two.

Fixes #56