### PR TITLE
Stop decoding uncompressed dictionary page padding as entries

### DIFF
--- a/docs/dictionary.ksy
+++ b/docs/dictionary.ksy
@@ -75,6 +75,12 @@ types:
         contents: [0xCD,0xAB,0xCD,0xAB]
         
 
+  # `allocation_size` is the page's capacity in BYTES, while the two counters
+  # above it are in UTF-16 characters:
+  #     allocation_size == 2 * (buffer_used_characters + remaining_store_available)
+  # Only the used characters are strings; the rest of the allocation is NUL
+  # slack and must not reach the NUL-split that turns this buffer into
+  # dictionary entries.
   uncompressed_strings:
     seq:
       - id: remaining_store_available
@@ -85,8 +91,10 @@ types:
         type: u8
       - id: uncompressed_character_buffer
         type: str
-        size: allocation_size
+        size: buffer_used_characters * 2
         encoding: UTF-16LE
+      - id: unused_store_padding
+        size: allocation_size - buffer_used_characters * 2
 
   compressed_strings:
     seq:

--- a/pbixray/column_data/dictionary.py
+++ b/pbixray/column_data/dictionary.py
@@ -239,7 +239,8 @@ class ColumnDataDictionary(KaitaiStruct):
             self.remaining_store_available = self._io.read_u8le()
             self.buffer_used_characters = self._io.read_u8le()
             self.allocation_size = self._io.read_u8le()
-            self.uncompressed_character_buffer = (self._io.read_bytes(self.allocation_size)).decode(u"UTF-16LE")
+            self.uncompressed_character_buffer = (self._io.read_bytes((self.buffer_used_characters * 2))).decode(u"UTF-16LE")
+            self.unused_store_padding = self._io.read_bytes((self.allocation_size - (self.buffer_used_characters * 2)))
 
 
         def _fetch_instances(self):

--- a/pbixray/vertipaq_decoder.py
+++ b/pbixray/vertipaq_decoder.py
@@ -130,7 +130,14 @@ class VertiPaqDecoder:
         return result.astype(np.int64) + min_data_id
 
     def _extract_strings(self,buffer):
-        """Extract zero-terminated strings from buffer."""
+        """Extract zero-terminated strings from buffer.
+
+        The buffer must be the page's *used* characters only. A page's
+        allocation is padded with NULs beyond `buffer_used_characters`, and
+        each of those would otherwise split off an extra empty entry, pushing
+        the data ids of every later page out by that much (see
+        `unused_store_padding` in the dictionary struct).
+        """
         strings = buffer.split('\0')
         return strings[:-1]  # remove the last empty string
 

--- a/test/test_dictionary_page_padding.py
+++ b/test/test_dictionary_page_padding.py
@@ -1,0 +1,119 @@
+"""Uncompressed dictionary pages must not decode their NUL padding as entries.
+
+A string dictionary is a list of pages, and an uncompressed page keeps its
+characters in a fixed allocation of which only ``buffer_used_characters`` are
+real; the tail is NUL slack. ``_extract_strings`` turns the buffer into entries
+by splitting on NUL, so decoding the whole allocation contributes one empty
+entry per unused character. ``_read_dictionary`` assigns data ids by walking
+pages in order and incrementing, so those phantom entries push the base index
+of every *later* page out by ``remaining_store_available``.
+
+Nothing raises when that happens. The shifted ids stay inside the dictionary,
+so the column simply returns another row's value -- and the pages that follow
+the uncompressed one are the Huffman-compressed ones, i.e. exactly where the
+long free-text values live.
+
+None of the sample models carry a padded page (2,246 uncompressed pages across
+the 27 readable samples, all of them exactly full), which is why this went
+unnoticed; a model large enough to spill a column's dictionary across pages is
+needed to produce one. The fixture is therefore synthetic: a two-page string
+dictionary built to the on-disk layout, with slack on the first page.
+
+The invariant the fix rests on -- ``allocation_size`` counts bytes while the
+two counters above it count UTF-16 characters, so
+
+    allocation_size == 2 * (buffer_used_characters + remaining_store_available)
+
+-- was verified to hold for all 2,246 sample pages plus 1,756 pages of two
+~650 MB models that do have padding.
+"""
+import io
+import struct
+
+import pytest
+
+from pbixray.column_data.dictionary import ColumnDataDictionary
+from pbixray.vertipaq_decoder import VertiPaqDecoder
+
+PAGE_BEGIN = b"\xDD\xCC\xBB\xAA"
+PAGE_END = b"\xCD\xAB\xCD\xAB"
+
+
+def _uncompressed_page(strings, slack_chars, start_index):
+    """One uncompressed string page carrying `slack_chars` NULs of padding."""
+    used = "".join(s + "\0" for s in strings)
+    used_chars = len(used)
+    alloc = 2 * (used_chars + slack_chars)
+    return b"".join([
+        struct.pack("<Q", 0),                       # page_mask
+        struct.pack("<B", 0),                       # page_contains_nulls
+        struct.pack("<Q", start_index),             # page_start_index
+        struct.pack("<Q", len(strings)),            # page_string_count
+        struct.pack("<B", 0),                       # page_compressed
+        PAGE_BEGIN,
+        struct.pack("<Q", slack_chars),             # remaining_store_available
+        struct.pack("<Q", used_chars),              # buffer_used_characters
+        struct.pack("<Q", alloc),                   # allocation_size
+        used.encode("utf-16-le") + b"\0" * (2 * slack_chars),
+        PAGE_END,
+    ])
+
+
+def _string_dictionary(pages_strings, slack_chars):
+    """A complete xm_type_string dictionary buffer; slack goes on page 0."""
+    total = sum(len(p) for p in pages_strings)
+    out = [
+        struct.pack("<i", 2),                       # dictionary_type: xm_type_string
+        struct.pack("<6i", 0, 8, 64, 6, -1, -1),    # hash_information
+        struct.pack("<q", total),                   # store_string_count
+        struct.pack("<b", 0),                       # f_store_compressed
+        struct.pack("<q", max(len(s) for p in pages_strings for s in p)),
+        struct.pack("<q", len(pages_strings)),      # store_page_count
+    ]
+    start = 0
+    for page_id, strings in enumerate(pages_strings):
+        out.append(_uncompressed_page(strings, slack_chars if page_id == 0 else 0, start))
+        start += len(strings)
+
+    out.append(struct.pack("<Q", total))            # record handle count
+    out.append(b"\x08\x00\x00\x00")                 # element_size
+    for page_id, strings in enumerate(pages_strings):
+        for i in range(len(strings)):
+            out.append(struct.pack("<II", i, page_id))
+    return b"".join(out)
+
+
+PAGE0 = ["alpha", "bravo", "charlie"]
+PAGE1 = ["delta", "echo"]
+
+
+@pytest.mark.parametrize("slack_chars", [0, 1, 873])
+def test_padding_is_not_decoded_as_entries(slack_chars):
+    """Data ids stay put no matter how much slack the first page carries."""
+    buffer = _string_dictionary([PAGE0, PAGE1], slack_chars)
+    decoder = VertiPaqDecoder.__new__(VertiPaqDecoder)   # no model needed
+    decoded = decoder._read_dictionary(buffer, min_data_id=3)
+
+    assert decoded.is_string
+    assert decoded.values == dict(enumerate(PAGE0 + PAGE1, start=3))
+
+
+def test_padding_is_read_but_kept_out_of_the_buffer():
+    """The page is still consumed whole -- the end marker has to line up."""
+    buffer = _string_dictionary([PAGE0, PAGE1], slack_chars=873)
+    with io.BytesIO(buffer) as f:
+        parsed = ColumnDataDictionary.from_io(f)
+
+    store = parsed.data.dictionary_pages[0].string_store
+    assert store.remaining_store_available == 873
+    assert len(store.unused_store_padding) == 2 * 873
+    assert store.allocation_size == 2 * (store.buffer_used_characters
+                                         + store.remaining_store_available)
+    assert store.uncompressed_character_buffer == "alpha\0bravo\0charlie\0"
+
+
+def test_sample_pages_are_unaffected(work_model):
+    """Sanity check on real data: unpadded pages decode as they always did."""
+    df = work_model.get_table("Currency")
+    assert len(df) == 105
+    assert df.loc[df["Code"] == "EUR", "Currency"].iloc[0] == "Euro"


### PR DESCRIPTION
Fixes #59.

### The bug

An uncompressed string page keeps its characters in a fixed allocation of which only `buffer_used_characters` are real; the rest is NUL slack. `uncompressed_strings` sized the buffer at `allocation_size`, so `_extract_strings` — which turns the buffer into entries by splitting on NUL — produced one empty entry per unused character.

`_read_dictionary` assigns data ids by walking pages in order and incrementing, so those phantom entries push the base index of every *later* page out by `remaining_store_available`. The pages that follow an uncompressed one are the Huffman-compressed ones, i.e. exactly where the long free-text values live.

Nothing raises. The shifted ids stay inside the dictionary, so the column just returns another row's value.

### The fix

`allocation_size` counts bytes while the two counters above it count UTF-16 characters:

```
allocation_size == 2 * (buffer_used_characters + remaining_store_available)
```

So the used span is `buffer_used_characters * 2`, and the remainder becomes an explicit `unused_store_padding` field rather than being dropped — the page still has to be consumed whole for the `0xABCDABCD` end marker to line up. `docs/dictionary.ksy` and the generated struct are changed together.

I verified that invariant on 2,246 uncompressed pages across the 27 readable samples plus 1,756 pages of two ~650 MB models that do have padding: it holds everywhere, so the padding length is never negative.

### Evidence

Found on a 650 MB model whose `Account` table has 164 columns; 16 came back with other accounts' text. Two checks pin it down without trusting decoder output:

- **`statistics.Cardinality`** is the engine's own distinct count. Each affected column fell short of it by exactly that column's `remaining_store_available`:

  | column | declared | decoded | short by | page padding |
  |---|---|---|---|---|
  | A | 4101 | 3228 | 873 | 873 |
  | B | 4020 | 3882 | 138 | 138 |
  | C | 6140 | 5678 | 462 | 462 |

  After the fix all 164 columns match their declared cardinality.

- **Cross-column consistency.** The model has pairs of columns where one holds a note history and the other only its newest entry, so the second must be a substring of the first. Measured over the whole table:

  | column pair | before | after |
  |---|---|---|
  | A_new / A_history | 15.9% | 99.4% |
  | B_new / B_history | 8.1% | 98.9% |
  | C_new / C_history | 17.6% | 99.8% |

### Test

No sample in `data/` carries a padded page — every one of those 2,246 uncompressed pages is exactly full, which is why this went unnoticed and why the change is a no-op for the existing suite (288 passed, 35 skipped, unchanged). Producing one needs a model large enough to spill a dictionary across pages.

The regression test is therefore synthetic: it builds a two-page string dictionary to the on-disk layout with slack on the first page, and asserts the id→value map. The zero-slack case is parametrized in as a control, and a second test asserts the page is still consumed whole. Without the struct change, the 1-char and 873-char cases fail and the 0-char one passes.

I can't share the model that surfaced this — it's confidential CRM data — so if you'd rather have a committed fixture I'm happy to try to construct a minimal `.pbix` that spills a dictionary across pages.
